### PR TITLE
-v09 of the draft

### DIFF
--- a/draft/draft-ietf-netconf-https-notif.xml
+++ b/draft/draft-ietf-netconf-https-notif.xml
@@ -30,11 +30,10 @@
     <keyword>notification</keyword>
 
     <abstract>
-      <t>This document defines both a protocol for sending notifications
-        over HTTPS as well as extensions to the data model for configured
-        subscriptions defined in RFC 8639.  It also presents an example
-        module for configuration without using the data model defined in
-        RFC 8639.</t>
+      <t>This document defines a protocol for sending notifications over
+      HTTPS. YANG modules for configuring publishers are also defined.
+      Examples are provided illustrating how to configure various publishers.
+      </t>
       <t>This document requires that the publisher is a "server" (e.g.,
         a NETCONF or RESTCONF server), but does not assume that the
         receiver is a server.</t>
@@ -68,7 +67,7 @@
         defined in <xref
         target="I-D.ietf-netconf-http-client-server">Groupings for HTTP
         Clients and Servers</xref>. For an example on how that can be done,
-        see Section 8.2.</t>
+        see Section A.2.</t>
       </section>
 
       <section title="Note to RFC Editor">
@@ -105,22 +104,22 @@
         when, they appear in all capitals, as shown here.</t>
 
         <section title="Subscribed Notifications">
-          <t>The following terms are defined in <xref target="RFC8639">Subscription
-            to YANG Notifications</xref>.</t>
-          <t><list style="symbols">
-              <t>Subscribed Notifications</t>
-            </list></t>
+          <t>The following terms are defined in <xref target="RFC8639">Subscription to YANG Notifications</xref>.
+	    <list style="symbols">
+	      <t>Subscribed Notifications</t>
+            </list>
+	  </t>
         </section>
       </section>
     </section>
 
     <section title="Overview of Publisher to Receiver Interaction">
-      <t>The protocol consists of two HTTP-based target resources presented by the receiver:
+      <t>The protocol consists of two HTTP-based target resources presented by the receiver. These two resources are sub-paths of a common resource that the publisher must know (e.g. specified in its configuration data model).
         <list style="symbols">
           <t>A target resource enabling the publisher to discover what optional 
-            capabilities a receiver supports.  Publishers SHOULD query this target
-            when before sending any notifications or if ever an error occurs.</t>
-          <t>A target resource enabling to publish to send one or more notification
+            capabilities a receiver supports. Publishers SHOULD query this target
+           before sending any notifications or if ever an error occurs.</t>
+          <t>A target resource enabling the publisher to send one or more notification
             to a receiver.  This document defines support for sending only one
             notification per message; a future effort MAY extend the protocol to
             send multiple notifications per message.</t>
@@ -157,7 +156,7 @@
         notification must be the "subscription-started" notification.</t>
       <t>The POST messages MAY be "pipelined" (not illustrated in the
         diagram above), whereby multiple notifications are sent without
-        waiting for the HTTP response for a previous request.</t>
+        waiting for the HTTP response for a previous POST.</t>
     </section>
 
     <section title="Discovering a Receiver's Capabilities">
@@ -166,14 +165,14 @@
           Notifications</xref>, dynamic discovery of a receiver's supported
           encoding is necessary only when the "/subscriptions/subscription/encoding"
           leaf is not configured, per the "encoding" leaf's description statement
-          in the "ietf-subscribed-notification" module.  FIXME: do they need
-          to discover *any* capabilities?</t>
+          in the "ietf-subscribed-notification" module.
+	</t>
       </section>
       <section title="Request">
         <t>To learn the capabilities of a receiver, a publisher can issue an
           HTTPS GET request to the "capabilities" resource under a known path on
           the receiver with "Accept" header set using the "application/xml"
-          and/or "application/json" media-types, with latter as the mandatory
+          and/or "application/json" media-types, with the latter as mandatory
           to implement, and the default in case the type is not specified.</t>
       </section>
       <section title="Response">
@@ -193,7 +192,7 @@
      the receiver.";
   leaf-list receiver-capability {
     type string {
-      pattern "urn:ietf:capability:https-notif-receiver:*";
+      pattern "inet:uri";
     }
     description
       "A capability supported by the receiver.  A full list of
@@ -204,12 +203,14 @@
             </artwork>
           </figure>
         </t>
+	<t>The publisher MUST ignore any capabilities that it does not recognize.
+	</t>
       </section>
       <section title="Example">
         <t>The publisher can send the following request to learn the receiver
           capabilities. In this example, the "Accept" states that the
-          receiver wants to receive notifications in XML but, if not
-          supported, to use JSON encoding.</t>
+          receiver wants to receive the capabilities response in XML but,
+	  if not supported, then in JSON.</t>
         <t>
           <figure>
             <artwork><![CDATA[GET /some/path/capabilities HTTP/1.1
@@ -268,7 +269,7 @@ Content-Length: nnn
         <t>The publisher sends an HTTPS POST request to the "relay-notifications"
           resource under a known path on the receiver with the "Content-Type"
           header set to either "application/json" or "application/xml" and a
-          request body containing the notification encoded using the specified
+          body containing the notification encoded using the specified
           format.</t>
         <t>XML-encoded notifications are encoded using the format defined
           by <xref target="RFC5277">NETCONF Event Notifications</xref>
@@ -280,7 +281,7 @@ Content-Length: nnn
             <t>The notifications do not contain the "data:" prefix used by SSE.</t>
             <t>Instead of saying that, for JSON-encoding purposes, the module
               name for the "notification" element is "ietf-restconf, the module
-              name will instead by "ietf-https-notif".</t>
+              name will instead be "ietf-https-notif".</t>
           </list>
         </t>
       </section>
@@ -298,7 +299,7 @@ Content-Type: application/xml
 <notification xmlns="urn:ietf:params:xml:ns:netconf:notification:1.0">
   <eventTime>2019-03-22T12:35:00Z</eventTime>
   <event xmlns="https://example.com/example-mod">
-    <event-class>fault</fault>
+    <event-class>fault</event-class>
     <reporting-entity>
       <card>Ethernet0</card>
     </reporting-entity>
@@ -373,7 +374,7 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-subscribed-notif-receivers@YYYY-MM-DD.yang,69)
           communicate with the receiver. The module augments the
           "ietf-subscribed-notif-receivers" module to define a transport specific
           receiver. </t>
-        <t>As mentioned earlier, it uses a POST method to deliver the
+        <t>As mentioned earlier, it uses an POST method to deliver the
           notification. The "http-receiver/tls/http-client-parameters/path" leaf
           defines the path for the resource on the receiver, as defined by
           "path-absolute" in <xref target="RFC3986">URI Generic Syntax</xref>.
@@ -504,7 +505,7 @@ reference:    RFC XXXX
 
       <section title='The "Capabilities for HTTPS Notification Receivers" Registry'>
 
-        <t>Following the guidelines defined in <xref target="RFC5226"/>,
+        <t>Following the guidelines defined in <xref target="RFC8126"/>,
           this document defines a new registry called "Capabilities for
           HTTPS Notification Receivers".  This registry defines capabilities
           that can be supported by HTTPS-based notification receivers.</t>
@@ -582,11 +583,10 @@ Record:
       <?rfc include='reference.RFC.8341'?>
       <?rfc include='reference.RFC.8446'?>
       <?rfc include='reference.RFC.8639'?>
-      <?rfc include='reference.I-D.ietf-netconf-notification-messages'?>
       <?rfc include='reference.I-D.ietf-netconf-http-client-server'?>
     </references>
     <references title="Informative references">
-      <?rfc include='reference.RFC.5226'?>
+      <?rfc include='reference.RFC.8126'?>
       <?rfc include='reference.RFC.8141'?>
     </references>
 

--- a/draft/draft-ietf-netconf-https-notif.xml
+++ b/draft/draft-ietf-netconf-https-notif.xml
@@ -266,7 +266,7 @@ Content-Length: nnn
 
     <section title="Sending Event Notifications"> 
       <section title="Request">
-        <t>The publisher sends an HTTPS POST request to the "relay-notifications"
+        <t>The publisher sends an HTTPS POST request to the "relay-notification"
           resource under a known path on the receiver with the "Content-Type"
           header set to either "application/json" or "application/xml" and a
           body containing the notification encoded using the specified

--- a/draft/draft-ietf-netconf-https-notif.xml
+++ b/draft/draft-ietf-netconf-https-notif.xml
@@ -22,7 +22,7 @@
       </address>
     </author>
 
-    <date day="16" month="November" year="2020"/>
+    <date day="22" month="February" year="2021"/>
     <area>Routing</area>
     <workgroup>NETCONF</workgroup>
     <keyword>http</keyword>
@@ -192,7 +192,7 @@
      the receiver.";
   leaf-list receiver-capability {
     type string {
-      pattern "inet:uri";
+      type "inet:uri";
     }
     description
       "A capability supported by the receiver.  A full list of
@@ -203,7 +203,9 @@
             </artwork>
           </figure>
         </t>
-	<t>The publisher MUST ignore any capabilities that it does not recognize.
+	<t>As it is possible that the receiver may return custom capability
+	URIs, the publisher MUST ignore any capabilities that it does not
+	recognize.
 	</t>
       </section>
       <section title="Example">
@@ -374,7 +376,7 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-subscribed-notif-receivers@YYYY-MM-DD.yang,69)
           communicate with the receiver. The module augments the
           "ietf-subscribed-notif-receivers" module to define a transport specific
           receiver. </t>
-        <t>As mentioned earlier, it uses an POST method to deliver the
+        <t>As mentioned earlier, it uses a POST method to deliver the
           notification. The "http-receiver/tls/http-client-parameters/path" leaf
           defines the path for the resource on the receiver, as defined by
           "path-absolute" in <xref target="RFC3986">URI Generic Syntax</xref>.

--- a/draft/draft-ietf-netconf-https-notif.xml
+++ b/draft/draft-ietf-netconf-https-notif.xml
@@ -5,8 +5,7 @@
   <?rfc toc="yes"?>
 
   <front>
-    <title abbrev="HTTPS-based Notification Transport">An HTTPS-based Transport for
-    Configured Subscriptions</title>
+    <title abbrev="An HTTPS-based Transport for YANG Notifications">An HTTPS-based Transport for YANG Notifications</title>
 
     <author fullname="Mahesh Jethanandani" initials="M.J." surname="Jethanandani">
       <organization>Kloud Services</organization>
@@ -191,9 +190,7 @@
     "A container for a list of capabilities supported by
      the receiver.";
   leaf-list receiver-capability {
-    type string {
-      type "inet:uri";
-    }
+    type "inet:uri";
     description
       "A capability supported by the receiver.  A full list of
        capabilities is defined in the 'Capabilities for HTTPS

--- a/draft/draft-ietf-netconf-https-notif.xml
+++ b/draft/draft-ietf-netconf-https-notif.xml
@@ -5,7 +5,7 @@
   <?rfc toc="yes"?>
 
   <front>
-    <title abbrev="An HTTPS-based Transport for YANG Notifications">An HTTPS-based Transport for YANG Notifications</title>
+    <title abbrev="HTTPS Notification Transport">An HTTPS-based Transport for YANG Notifications</title>
 
     <author fullname="Mahesh Jethanandani" initials="M.J." surname="Jethanandani">
       <organization>Kloud Services</organization>
@@ -21,8 +21,8 @@
       </address>
     </author>
 
-    <date day="22" month="February" year="2021"/>
-    <area>Routing</area>
+    <date/>
+    <area>Operations</area>
     <workgroup>NETCONF</workgroup>
     <keyword>http</keyword>
     <keyword>yang</keyword>
@@ -112,17 +112,25 @@
       </section>
     </section>
 
-    <section title="Overview of Publisher to Receiver Interaction">
-      <t>The protocol consists of two HTTP-based target resources presented by the receiver. These two resources are sub-paths of a common resource that the publisher must know (e.g. specified in its configuration data model).
-        <list style="symbols">
-          <t>A target resource enabling the publisher to discover what optional 
-            capabilities a receiver supports. Publishers SHOULD query this target
-           before sending any notifications or if ever an error occurs.</t>
-          <t>A target resource enabling the publisher to send one or more notification
-            to a receiver.  This document defines support for sending only one
-            notification per message; a future effort MAY extend the protocol to
-            send multiple notifications per message.</t>
-        </list>
+    <section title="Overview of Publisher to Receiver Interaction" anchor="overview">
+      <t>The protocol consists of two HTTP-based target resources presented by
+      the receiver.  These two resources share a common prefix
+      that the publisher must know. If the data model in section 6.2 is
+      used, this common prefix is defined by the "path" leaf in the
+      "http-client-parameters" container.
+
+      <list style="symbols">
+	<t>"capabilities":  A target resource enabling the publisher
+	to discover what optional capabilities a receiver supports.
+	Publishers SHOULD query this target before sending any
+	notifications or if ever an error occurs.</t>
+
+	<t>"relay-notifications":  A target resource enabling the publisher
+	to send one or more notification to a receiver.  This document
+	defines support for sending only one notification per message; a
+	future effort MAY extend the protocol to send multiple
+	notifications per message.</t>
+      </list>
       </t>
       <t>The protocol is illustrated in the diagram below:</t>
       <t>
@@ -169,7 +177,7 @@
       </section>
       <section title="Request">
         <t>To learn the capabilities of a receiver, a publisher can issue an
-          HTTPS GET request to the "capabilities" resource under a known path on
+          HTTPS GET request to the "capabilities" resource (see <xref target= "overview"/>) on
           the receiver with "Accept" header set using the "application/xml"
           and/or "application/json" media-types, with the latter as mandatory
           to implement, and the default in case the type is not specified.</t>
@@ -192,9 +200,10 @@
   leaf-list receiver-capability {
     type "inet:uri";
     description
-      "A capability supported by the receiver.  A full list of
+      "A capability supported by the receiver.  A partial list of
        capabilities is defined in the 'Capabilities for HTTPS
-       Notification Receivers' registry (see RFC XXXX).";
+       Notification Receivers' registry (see RFC XXXX). Additional
+       custom capabilities MAY be defined.";
   }
 }
             </artwork>
@@ -218,8 +227,9 @@ Accept: application/xml, application/json]]></artwork>
           </figure>
         </t>
         <t>If the receiver is able to reply using "application/xml", and
-          assuming it is able to receive JSON and XML encoded notifications, the
-          response might look like this:</t>
+        assuming it is able to receive JSON and XML encoded notifications,
+	and it is able to process the RFC 8639 state machine, the
+        response might look like this:</t>
         <t>
           <figure>
             <artwork><![CDATA[HTTP/1.1 200 OK
@@ -235,6 +245,9 @@ Content-Length: nnn
   </receiver-capability>
   <receiver-capability>\
     urn:ietf:capability:https-notif-receiver:encoding:xml\
+  </receiver-capability>
+  <receiver-capability>\
+    urn:ietf:capability:https-notif-receiver:encoding:sub-notif\
   </receiver-capability>
 </receiver-capabilities>]]></artwork>
           </figure>
@@ -254,7 +267,8 @@ Content-Length: nnn
    receiver-capabilities {
      "receiver-capability": [
        "urn:ietf:capability:https-notif-receiver:encoding:json",
-       "urn:ietf:capability:https-notif-receiver:encoding:xml"
+       "urn:ietf:capability:https-notif-receiver:encoding:xml",
+       "urn:ietf:capability:https-notif-receiver:encoding:sub-notif"
      ]
    }
 }]]></artwork>
@@ -266,7 +280,7 @@ Content-Length: nnn
     <section title="Sending Event Notifications"> 
       <section title="Request">
         <t>The publisher sends an HTTPS POST request to the "relay-notification"
-          resource under a known path on the receiver with the "Content-Type"
+          resource (see <xref target= "overview"/>) on the receiver with the "Content-Type"
           header set to either "application/json" or "application/xml" and a
           body containing the notification encoded using the specified
           format.</t>
@@ -558,6 +572,13 @@ Record:
    Name:        urn:ietf:capability:https-notif-receiver:encoding:xml
    Reference:   RFC XXXX
    Description: Identifies support for XML-encoded notifications.
+
+Record:
+   Name:        urn:ietf:capability:https-notif-receiver:encoding:sub-notif
+   Reference:   RFC XXXX
+   Description: Identifies support for state machine described in
+                RFC 8639, enabling the publisher to send, e.g., the
+                "subscription-started" notification.
 </artwork>
           </figure>
         </t>
@@ -568,25 +589,25 @@ Record:
 
   <back>
     <references title="Normative references">
-      <?rfc include='reference.RFC.2119'?>
-      <?rfc include='reference.RFC.3688'?>
-      <?rfc include='reference.RFC.3986'?>
-      <?rfc include='reference.RFC.5277'?>
-      <?rfc include='reference.RFC.6020'?>
-      <?rfc include='reference.RFC.6241'?>
-      <?rfc include='reference.RFC.6242'?>
-      <?rfc include='reference.RFC.7407'?>
-      <?rfc include='reference.RFC.7950'?>
-      <?rfc include='reference.RFC.8040'?>
-      <?rfc include='reference.RFC.8174'?>
-      <?rfc include='reference.RFC.8341'?>
-      <?rfc include='reference.RFC.8446'?>
-      <?rfc include='reference.RFC.8639'?>
-      <?rfc include='reference.I-D.ietf-netconf-http-client-server'?>
+      <?rfc include='reference.RFC.2119.xml'?>
+      <?rfc include='reference.RFC.3688.xml'?>
+      <?rfc include='reference.RFC.3986.xml'?>
+      <?rfc include='reference.RFC.5277.xml'?>
+      <?rfc include='reference.RFC.6020.xml'?>
+      <?rfc include='reference.RFC.6241.xml'?>
+      <?rfc include='reference.RFC.6242.xml'?>
+      <?rfc include='reference.RFC.7407.xml'?>
+      <?rfc include='reference.RFC.7950.xml'?>
+      <?rfc include='reference.RFC.8040.xml'?>
+      <?rfc include='reference.RFC.8174.xml'?>
+      <?rfc include='reference.RFC.8341.xml'?>
+      <?rfc include='reference.RFC.8446.xml'?>
+      <?rfc include='reference.RFC.8639.xml'?>
+      <?rfc include='reference.I-D.ietf-netconf-http-client-server.xml'?>
     </references>
     <references title="Informative references">
-      <?rfc include='reference.RFC.8126'?>
-      <?rfc include='reference.RFC.8141'?>
+      <?rfc include='reference.RFC.8126.xml'?>
+      <?rfc include='reference.RFC.8141.xml'?>
     </references>
 
     <section title="Configuration Examples">

--- a/src/insert-figures.sh
+++ b/src/insert-figures.sh
@@ -1,35 +1,34 @@
 #!/bin/bash
 
+#FOLD=rfcfold
+FOLD=rfcfold
+
 # make sure input params are good
 if [ "$#" == "0" ]; then
-    echo "Usage: $0 file[,fold-length]"
-    exit
+  echo "Usage: $0 file[,fold-length]"
+  exit
 fi
 
 cp $1 .tmp.new.txt
 while ( grep INSERT_TEXT_FROM_FILE .tmp.new.txt >> /dev/null ); do
-    i=`grep -n INSERT_TEXT_FROM_FILE .tmp.new.txt | head -1`
-    linenum=`echo $i | sed 's/:.*//'`
-    file=`echo $i | sed 's/.*(\(.*\))/\1/'`
+  i=`grep -n INSERT_TEXT_FROM_FILE .tmp.new.txt | head -1`
+  linenum=`echo $i | sed 's/:.*//'`
+  file=`echo $i | sed 's/.*(\(.*\))/\1/'`
 
-    awk "NR<$linenum" .tmp.new.txt > .tmp.pre.txt
-    awk "NR>$linenum" .tmp.new.txt > .tmp.post.txt
+  awk "NR<$linenum" .tmp.new.txt > .tmp.pre.txt
+  awk "NR>$linenum" .tmp.new.txt > .tmp.post.txt
 
-    if [ `echo $file | grep ","` ]; then
-      col=`echo $file | sed 's/.*,//'`
-      file=`echo $file | sed 's/,.*//'`
-      file2=$file.2
-      echo "[note: '\' line wrapping for formatting only]" > $file2
-      echo "" >> $file2
-      gsed "s/\(.\{$col\}\)/\1\\\\\n/" < $file >> $file2
-      cat .tmp.pre.txt $file2 .tmp.post.txt > .tmp.new.txt
-      rm $file2
-    else
-      cat .tmp.pre.txt $file .tmp.post.txt > .tmp.new.txt
-    fi
+  if [ `echo $file | grep ","` ]; then
+    col=`echo $file | sed 's/.*,//'`
+    file=`echo $file | sed 's/,.*//'`
+    $FOLD -c $col -i $file -o $file.potentially-folded
+  else
+    $FOLD -i $file -o $file.potentially-folded
+  fi
+
+  cat .tmp.pre.txt $file.potentially-folded .tmp.post.txt > .tmp.new.txt
+  rm $file.potentially-folded
 done
 
 cat .tmp.new.txt
 rm .tmp.pre.txt .tmp.post.txt .tmp.new.txt
-
-

--- a/src/validate-and-gen-trees.sh
+++ b/src/validate-and-gen-trees.sh
@@ -3,11 +3,11 @@
 for i in ../bin/*\@$(date +%Y-%m-%d).yang
 do
     name=$(echo $i | cut -f 1-3 -d '.')
-    echo "Validating YANG module $name.yang"
+    echo "Validating YANG module $name.yang using pyang"
     if test "${name#^example}" = "$name"; then
-        response=`pyang --lint --strict --canonical -p ../bin -f tree --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
+        response=`pyang --lint --strict --canonical -p ../../iana/yang-parameters -p ../bin -f tree --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
     else            
-        response=`pyang --ietf --strict --canonical -p ../bin -f tree --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
+        response=`pyang --ietf --strict --canonical -p ../../iana/yang-parameters -p ../bin -f tree --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
     fi
     if [ $? -ne 0 ]; then
         printf "$name.yang failed pyang validation\n"
@@ -16,7 +16,9 @@ do
 	rm yang/*-tree.txt.tmp
         exit 1
     fi
+    echo "Validation of YANG module $name.yang using pyang succeeded."
     fold -w 71 $name-tree.txt.tmp > $name-tree.txt
+    echo "Validating YANG module $name.yang using yanglint"
     response=`yanglint -p ../src/yang $name.yang -i`
     if [ $? -ne 0 ]; then
        printf "$name.yang failed yanglint validation\n"
@@ -24,7 +26,7 @@ do
        echo
        exit 1
    fi
-   echo "$name.yang is VALID"
+   echo "Validation of $name.yang using yanglint succeeded."
 done
 rm ../bin/*-tree.txt.tmp
 
@@ -33,9 +35,9 @@ do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Generating abridged tree diagram for $name.yang"
     if test "${name#^example}" = "$name"; then
-       response=`pyang --lint --strict --canonical -p ../bin/submodules -p ../bin -f tree --tree-depth=7 --max-line-length=69 --tree-line-length=69 $name.yang > $name-sub-tree.txt.tmp`
+       response=`pyang --lint --strict --canonical -p ../../iana/yang-parameters/ -p ../bin -f tree --tree-depth=7 --max-line-length=69 --tree-line-length=69 $name.yang > $name-sub-tree.txt.tmp`
     else            
-       response=`pyang --ietf --strict --canonical -p ../bin/submodules -p ../bin -f tree --tree-depth=3 --max-line-length=69 --tree-line-length=69 $name.yang > $name-sub-tree.txt.tmp`
+       response=`pyang --ietf --strict --canonical -p ../../iana/yang-parameters/ -p ../bin -f tree --tree-depth=3 --max-line-length=69 --tree-line-length=69 $name.yang > $name-sub-tree.txt.tmp`
     fi
     if [ $? -ne 0 ]; then
         printf "$name.yang failed generation of sub-tree diagram\n"
@@ -54,7 +56,7 @@ for i in yang/example-https-notif-*.xml
 do
     name=$(echo $i | cut -f 1-2 -d '.')
     echo "Validating examples for $name.xml"
-    response=`yanglint -s -i -t auto -p ../bin ../bin/ietf-https-notif-transport\@$(date +%Y-%m-%d).yang $name.xml`
+    response=`yanglint -ii -t config -p ../bin -p ../../iana/yang-parameters ../bin/ietf-https-notif-transport\@$(date +%Y-%m-%d).yang $name.xml`
     if [ $? -ne 0 ]; then
        printf "failed (error code: $?)\n"
        printf "$response\n\n"
@@ -68,7 +70,7 @@ for i in yang/example-custom-https-notif.xml
 do
     name=$(echo $i | cut -f 1 -d '.')
     echo "Validating examples for $name.xml"
-    response=`yanglint -s -i -t auto -p ../bin ../bin/example-custom-module\@$(date +%Y-%m-%d).yang $name.xml`
+    response=`yanglint -ii -t config -p ../bin -p ../../iana/yang-parameters ../bin/example-custom-module\@$(date +%Y-%m-%d).yang $name.xml`
     if [ $? -ne 0 ]; then
        printf "failed (error code: $?)\n"
        printf "$response\n\n"

--- a/src/yang/example-custom-https-notif.xml
+++ b/src/yang/example-custom-https-notif.xml
@@ -1,58 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
-  <example-module xmlns="http://example.com/example-custom-module">
-    <https-receivers>
-      <https-receiver>
-        <name>foo</name>
-        <tls>
-          <tcp-client-parameters>
-            <remote-address>receiver.example.com</remote-address>
-            <remote-port>443</remote-port>
-          </tcp-client-parameters>
-          <tls-client-parameters>
-            <server-authentication>
-              <ca-certs>
-                <local-definition>
-                  <certificate>
-                    <name>Server Cert Issuer #1</name>
-                    <cert-data>base64encodedvalue==</cert-data>
-                  </certificate>
-                </local-definition>
-              </ca-certs>
-            </server-authentication>
-          </tls-client-parameters>
-          <http-client-parameters>
-            <client-identity>
-              <basic>
-                <user-id>my-name</user-id>
-                <cleartext-password>my-password</cleartext-password>
-              </basic>
-            </client-identity>
-            <path>/some/path</path>
-          </http-client-parameters>
-        </tls>
-      </https-receiver>
-    </https-receivers>
-  </example-module>
-  <truststore xmlns="urn:ietf:params:xml:ns:yang:ietf-truststore">
-    <certificate-bags>
-      <certificate-bag>
-        <name>explicitly-trusted-server-ca-certs</name>
-        <description>
-          Trust anchors (i.e. CA certs) that are used to
-          authenticate connections to receivers.  Receivers
-          are authenticated if their certificate has a chain
-          of trust to one of these CA certificates.
-        </description>
-        <certificate>
-          <name>ca.example.com</name>
-          <cert-data>base64encodedvalue==</cert-data>
-        </certificate>
-        <certificate>
-          <name>Fred Flintstone</name>
-          <cert-data>base64encodedvalue==</cert-data>
-        </certificate>
-      </certificate-bag>
-    </certificate-bags>
-  </truststore>
-</config>
+<example-module xmlns="http://example.com/example-custom-module">
+  <https-receivers>
+    <https-receiver>
+      <name>foo</name>
+      <tls>
+        <tcp-client-parameters>
+          <remote-address>receiver.example.com</remote-address>
+          <remote-port>443</remote-port>
+        </tcp-client-parameters>
+        <tls-client-parameters>
+          <server-authentication>
+            <ca-certs>
+              <local-definition>
+                <certificate>
+                  <name>Server Cert Issuer #1</name>
+                  <cert-data>base64encodedvalue==</cert-data>
+                </certificate>
+              </local-definition>
+            </ca-certs>
+          </server-authentication>
+        </tls-client-parameters>
+        <http-client-parameters>
+          <client-identity>
+            <basic>
+              <user-id>my-name</user-id>
+              <cleartext-password>my-password</cleartext-password>
+            </basic>
+          </client-identity>
+          <path>/some/path</path>
+        </http-client-parameters>
+      </tls>
+    </https-receiver>
+  </https-receivers>
+</example-module>

--- a/src/yang/example-https-notif-7.1.xml
+++ b/src/yang/example-https-notif-7.1.xml
@@ -1,86 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
-  <subscriptions
-      xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
-    <receiver-instances
-        xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notif-receivers">
-      <receiver-instance>
-        <name>global-receiver-def</name>
-        <https-receiver
-            xmlns="urn:ietf:params:xml:ns:yang:ietf-https-notif-transport"
+<subscriptions
+    xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+  <receiver-instances
+      xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notif-receivers">
+    <receiver-instance>
+      <name>global-receiver-def</name>
+      <https-receiver
+          xmlns="urn:ietf:params:xml:ns:yang:ietf-https-notif-transport"
           xmlns:x509c2n="urn:ietf:params:xml:ns:yang:ietf-x509-cert-to-name">
-          <tls>
-            <tcp-client-parameters>
-              <remote-address>receiver.example.com</remote-address>
-              <remote-port>443</remote-port>
-            </tcp-client-parameters>
-            <tls-client-parameters>
-              <server-authentication>
-                <ca-certs>
-                  <local-definition>
-                    <certificate>
-                      <name>Server Cert Issuer #1</name>
-                      <cert-data>base64encodedvalue==</cert-data>
-                    </certificate>
-                  </local-definition>
-                </ca-certs>
-              </server-authentication>
-            </tls-client-parameters>
-            <http-client-parameters>
-              <client-identity>
-                <basic>
-                  <user-id>my-name</user-id>
-                  <cleartext-password>my-password</cleartext-password>
-                </basic>
-              </client-identity>
-              <path>/some/path</path>
-            </http-client-parameters>
-          </tls>
-          <receiver-identity>
-            <cert-maps>
-              <cert-to-name>
-                <id>1</id>
-                <fingerprint>11:0A:05:11:00</fingerprint>
-                <map-type>x509c2n:san-any</map-type>
-              </cert-to-name>
-            </cert-maps>
-          </receiver-identity>
-        </https-receiver>
-      </receiver-instance>
-    </receiver-instances>
-    <subscription>
-      <id>6666</id>
-      <transport xmlns:ph="urn:ietf:params:xml:ns:yang:ietf-https-notif-transport">ph:https</transport>
-      <stream-subtree-filter>some-subtree-filter</stream-subtree-filter>
-      <stream>some-stream</stream>
-      <receivers>
-        <receiver>
-          <name>subscription-specific-receiver-def</name>
-          <receiver-instance-ref xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notif-receivers">global-receiver-def</receiver-instance-ref>
-        </receiver>
-      </receivers>
-    </subscription>
-  </subscriptions>
-  <truststore xmlns="urn:ietf:params:xml:ns:yang:ietf-truststore">
-    <certificate-bags>
-      <certificate-bag>
-        <name>explicitly-trusted-server-ca-certs</name>
-        <description>
-          Trust anchors (i.e. CA certs) that are used to
-          authenticate connections to receivers.  Receivers
-          are authenticated if their certificate has a chain
-          of trust to one of these CA certificates.
-          certificates.
-        </description>
-        <certificate>
-          <name>ca.example.com</name>
-          <cert-data>base64encodedvalue==</cert-data>
-        </certificate>
-        <certificate>
-          <name>Fred Flintstone</name>
-          <cert-data>base64encodedvalue==</cert-data>
-        </certificate>
-      </certificate-bag>
-    </certificate-bags>
-  </truststore>
-</config>
+        <tls>
+          <tcp-client-parameters>
+            <remote-address>receiver.example.com</remote-address>
+            <remote-port>443</remote-port>
+          </tcp-client-parameters>
+          <tls-client-parameters>
+            <server-authentication>
+              <ca-certs>
+                <local-definition>
+                  <certificate>
+                    <name>Server Cert Issuer #1</name>
+                    <cert-data>base64encodedvalue==</cert-data>
+                  </certificate>
+                </local-definition>
+              </ca-certs>
+            </server-authentication>
+          </tls-client-parameters>
+          <http-client-parameters>
+            <client-identity>
+              <basic>
+                <user-id>my-name</user-id>
+                <cleartext-password>my-password</cleartext-password>
+              </basic>
+            </client-identity>
+            <path>/some/path</path>
+          </http-client-parameters>
+        </tls>
+        <receiver-identity>
+          <cert-maps>
+            <cert-to-name>
+              <id>1</id>
+              <fingerprint>11:0A:05:11:00</fingerprint>
+              <map-type>x509c2n:san-any</map-type>
+            </cert-to-name>
+          </cert-maps>
+        </receiver-identity>
+      </https-receiver>
+    </receiver-instance>
+  </receiver-instances>
+  <subscription>
+    <id>6666</id>
+    <transport xmlns:ph="urn:ietf:params:xml:ns:yang:ietf-https-notif-transport">ph:https</transport>
+    <stream-subtree-filter>some-subtree-filter</stream-subtree-filter>
+    <stream>some-stream</stream>
+    <receivers>
+      <receiver>
+        <name>subscription-specific-receiver-def</name>
+        <receiver-instance-ref xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notif-receivers">global-receiver-def</receiver-instance-ref>
+      </receiver>
+    </receivers>
+  </subscription>
+</subscriptions>
+<truststore xmlns="urn:ietf:params:xml:ns:yang:ietf-truststore">
+  <certificate-bags>
+    <certificate-bag>
+      <name>explicitly-trusted-server-ca-certs</name>
+      <description>
+        Trust anchors (i.e. CA certs) that are used to
+        authenticate connections to receivers.  Receivers
+        are authenticated if their certificate has a chain
+        of trust to one of these CA certificates.
+        certificates.
+      </description>
+      <certificate>
+        <name>ca.example.com</name>
+        <cert-data>base64encodedvalue==</cert-data>
+      </certificate>
+      <certificate>
+        <name>Fred Flintstone</name>
+        <cert-data>base64encodedvalue==</cert-data>
+      </certificate>
+    </certificate-bag>
+  </certificate-bags>
+</truststore>

--- a/src/yang/example-https-notif-7.1.xml
+++ b/src/yang/example-https-notif-7.1.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
-  <subscriptions xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
-    <receiver-instances xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notif-receivers">
+  <subscriptions
+      xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+    <receiver-instances
+        xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notif-receivers">
       <receiver-instance>
         <name>global-receiver-def</name>
-        <https-receiver xmlns="urn:ietf:params:xml:ns:yang:ietf-https-notif-transport"
+        <https-receiver
+            xmlns="urn:ietf:params:xml:ns:yang:ietf-https-notif-transport"
           xmlns:x509c2n="urn:ietf:params:xml:ns:yang:ietf-x509-cert-to-name">
           <tls>
             <tcp-client-parameters>

--- a/src/yang/ietf-https-notif-transport.yang
+++ b/src/yang/ietf-https-notif-transport.yang
@@ -106,7 +106,7 @@ module ietf-https-notif-transport {
         }
         description
           "Augmentation to add a receiver-specific path for the
-          'capabilities' and 'relay-notification' resources.";
+           'capabilities' and 'relay-notification' resources.";
       }
     }
     container receiver-identity {

--- a/src/yang/ietf-https-notif-transport.yang
+++ b/src/yang/ietf-https-notif-transport.yang
@@ -44,7 +44,7 @@ module ietf-https-notif-transport {
 
      This module augments a 'case' statement called 'https' into
      the 'choice' statement called 'transport-type' defined
-     by the 'ietf-https-notif-transport' module defined in RFC XXXX. 
+     by the 'ietf-https-notif-transport' module defined in RFC XXXX.
 
      Copyright (c) 2021 IETF Trust and the persons identified as
      the document authors.  All rights reserved.
@@ -73,7 +73,7 @@ module ietf-https-notif-transport {
 
   feature receiver-identity {
     description
-      "Indicates if the server supports filtering notifications
+      "Indicates that the server supports filtering notifications
        based on the receiver's identity derived from its TLS
        certificate.";
   }
@@ -106,7 +106,7 @@ module ietf-https-notif-transport {
         }
         description
           "Augmentation to add a receiver-specific path for the
-           'capabilities' and 'relay-notification' resources.";
+          'capabilities' and 'relay-notification' resources.";
       }
     }
     container receiver-identity {

--- a/src/yang/ietf-subscribed-notif-receivers.yang
+++ b/src/yang/ietf-subscribed-notif-receivers.yang
@@ -108,5 +108,4 @@ module ietf-subscribed-notif-receivers {
       "Augment the subscriptions container to define an optional
        reference to a receiver instance.";
   }
-
 }


### PR DESCRIPTION
Getting the draft ready for publication.

Did file a bug with libyang folks and even though it was an operator error on my part, the default in yanglint now is to enable all features when none are mentioned. The examples now validate correctly.