### PR TITLE
Reflect changes in draft-ietf-netconf-http-client-server draft

### DIFF
--- a/draft/draft-ietf-netconf-https-notif.xml
+++ b/draft/draft-ietf-netconf-https-notif.xml
@@ -720,7 +720,6 @@ Record:
       <?rfc include='reference.RFC.8341.xml'?>
       <?rfc include='reference.RFC.8446.xml'?>
       <?rfc include='reference.RFC.8639.xml'?>
-      <?rfc include='reference.RFC.9000.xml'?>
       <?rfc include='reference.RFC.9110.xml'?>
       <?rfc include='reference.RFC.9112.xml'?>
       <?rfc include='reference.RFC.9113.xml'?>

--- a/src/download-dependent-models.py
+++ b/src/download-dependent-models.py
@@ -3,14 +3,8 @@ import os
 list_of_ietf_models =\
 [ ["ietf-crypto-types", "draft-ietf-netconf-crypto-types", "34"],
   ["ietf-truststore", "draft-ietf-netconf-trust-anchors", "28"],
-  ["ietf-keystore", "draft-ietf-netconf-keystore", "35"],
-  ["ietf-tcp-common", "draft-ietf-netconf-tcp-client-server", "26"],
-  ["ietf-tcp-client", "draft-ietf-netconf-tcp-client-server", "26"],
-  ["ietf-tls-client", "draft-ietf-netconf-tls-client-server", "41"],
-  ["ietf-tls-common", "draft-ietf-netconf-tls-client-server", "41"],
-  ["ietf-tls-server", "draft-ietf-netconf-tls-client-server", "41"],
   ["iana-tls-cipher-suite-algs", "draft-ietf-netconf-tls-client-server", "41"],
-  ["ietf-http-client", "draft-ietf-netconf-http-client-server", "21"] ]
+  ["ietf-http-client", "draft-ietf-netconf-http-client-server", "23"] ]
 
 
 def fetch_and_extract(draft, module, version):

--- a/src/download-dependent-models.py
+++ b/src/download-dependent-models.py
@@ -1,16 +1,16 @@
 import os
 
 list_of_ietf_models =\
-[ ["ietf-crypto-types", "draft-ietf-netconf-crypto-types", "25"],
-  ["ietf-truststore", "draft-ietf-netconf-trust-anchors", "19"],
-  ["ietf-keystore", "draft-ietf-netconf-keystore", "26"],
-  ["ietf-tcp-common", "draft-ietf-netconf-tcp-client-server", "14"],
-  ["ietf-tcp-client", "draft-ietf-netconf-tcp-client-server", "14"],
-  ["ietf-tls-client", "draft-ietf-netconf-tls-client-server", "31"],
-  ["ietf-tls-common", "draft-ietf-netconf-tls-client-server", "31"],
-  ["ietf-tls-server", "draft-ietf-netconf-tls-client-server", "31"],
-  ["iana-tls-cipher-suite-algs", "draft-ietf-netconf-tls-client-server", "31"],
-  ["ietf-http-client", "draft-ietf-netconf-http-client-server", "11"] ]
+[ ["ietf-crypto-types", "draft-ietf-netconf-crypto-types", "34"],
+  ["ietf-truststore", "draft-ietf-netconf-trust-anchors", "28"],
+  ["ietf-keystore", "draft-ietf-netconf-keystore", "35"],
+  ["ietf-tcp-common", "draft-ietf-netconf-tcp-client-server", "26"],
+  ["ietf-tcp-client", "draft-ietf-netconf-tcp-client-server", "26"],
+  ["ietf-tls-client", "draft-ietf-netconf-tls-client-server", "41"],
+  ["ietf-tls-common", "draft-ietf-netconf-tls-client-server", "41"],
+  ["ietf-tls-server", "draft-ietf-netconf-tls-client-server", "41"],
+  ["iana-tls-cipher-suite-algs", "draft-ietf-netconf-tls-client-server", "41"],
+  ["ietf-http-client", "draft-ietf-netconf-http-client-server", "21"] ]
 
 
 def fetch_and_extract(draft, module, version):

--- a/src/yang/example-custom-https-notif.xml
+++ b/src/yang/example-custom-https-notif.xml
@@ -3,33 +3,36 @@
   <https-receivers>
     <https-receiver>
       <name>foo</name>
-      <tls>
-        <tcp-client-parameters>
-          <remote-address>receiver.example.com</remote-address>
-          <remote-port>443</remote-port>
-        </tcp-client-parameters>
+      <capabilities-endpoint>
+        <uri>receiver.example.com:443/some-path</uri>
         <tls-client-parameters>
           <server-authentication>
             <ca-certs>
-              <local-definition>
+              <inline-definition>
                 <certificate>
                   <name>Server Cert Issuer #1</name>
                   <cert-data>base64encodedvalue==</cert-data>
                 </certificate>
-              </local-definition>
+              </inline-definition>
             </ca-certs>
           </server-authentication>
         </tls-client-parameters>
-        <http-client-parameters>
-          <client-identity>
-            <basic>
-              <user-id>my-name</user-id>
-              <cleartext-password>my-password</cleartext-password>
-            </basic>
-          </client-identity>
-          <path>/some/path</path>
-        </http-client-parameters>
-      </tls>
+      </capabilities-endpoint>
+      <relay-notification-endpoint>
+        <uri>receiver.example.com:443/some-path</uri>
+        <tls-client-parameters>
+          <server-authentication>
+            <ca-certs>
+              <inline-definition>
+                <certificate>
+                  <name>Server Cert Issuer #1</name>
+                  <cert-data>base64encodedvalue==</cert-data>
+                </certificate>
+              </inline-definition>
+            </ca-certs>
+          </server-authentication>
+        </tls-client-parameters>
+      </relay-notification-endpoint>
     </https-receiver>
   </https-receivers>
 </example-module>

--- a/src/yang/example-custom-module.yang
+++ b/src/yang/example-custom-module.yang
@@ -3,11 +3,11 @@ module example-custom-module {
   namespace "http://example.com/example-custom-module";
   prefix "custom";
 
-  import ietf-https-notif-transport {
-    prefix "hnt";
+  import ietf-http-client {
+    prefix "httpc";
     reference
-      "RFC XXXX:
-        An HTTPS-based Transport for Configured Subscriptions";
+      "I-D.ietf-netconf-http-client-server:
+        YANG Groupings for HTTP Clients and HTTP Servers.";
   }
 
   organization
@@ -43,7 +43,7 @@ module example-custom-module {
          description
            "A unique name for the https notif receiver.";
        }
-        uses hnt:https-receiver-grouping;
+        uses httpc:http-client-grouping;
       }
     }
   }

--- a/src/yang/example-custom-module.yang
+++ b/src/yang/example-custom-module.yang
@@ -3,11 +3,10 @@ module example-custom-module {
   namespace "http://example.com/example-custom-module";
   prefix "custom";
 
-  import ietf-http-client {
-    prefix "httpc";
+  import ietf-https-notif-transport {
+    prefix "hnt";
     reference
-      "I-D.ietf-netconf-http-client-server:
-        YANG Groupings for HTTP Clients and HTTP Servers.";
+      "RFC XXXX: An HTTPS-based Transport for YANG Notifications.";
   }
 
   organization
@@ -35,15 +34,15 @@ module example-custom-module {
       description
         "A container of all HTTPS notif receivers.";
       list https-receiver {
-       key "name";
+        key "name";
         description
           "A list of HTTPS notif receivers.";
-       leaf name {
-         type string;
-         description
-           "A unique name for the https notif receiver.";
-       }
-        uses httpc:http-client-grouping;
+        leaf name {
+          type string;
+          description
+            "A unique name for the https notif receiver.";
+        }
+        uses hnt:https-receiver-grouping;
       }
     }
   }

--- a/src/yang/example-custom-module.yang
+++ b/src/yang/example-custom-module.yang
@@ -40,7 +40,7 @@ module example-custom-module {
         leaf name {
           type string;
           description
-            "A unique name for the https notif receiver.";
+            "A unique name for the https-notif receiver.";
         }
         uses hnt:https-receiver-grouping;
       }

--- a/src/yang/example-https-notif-7.1.xml
+++ b/src/yang/example-https-notif-7.1.xml
@@ -8,34 +8,36 @@
       <https-receiver
           xmlns="urn:ietf:params:xml:ns:yang:ietf-https-notif-transport"
           xmlns:x509c2n="urn:ietf:params:xml:ns:yang:ietf-x509-cert-to-name">
-        <tls>
-          <tcp-client-parameters>
-            <remote-address>receiver.example.com</remote-address>
-            <remote-port>443</remote-port>
-          </tcp-client-parameters>
+        <capabilities-endpoint>
+          <uri>receiver.example.com:443/some-path</uri>
           <tls-client-parameters>
             <server-authentication>
               <ca-certs>
-                <local-definition>
+                <inline-definition>
                   <certificate>
                     <name>Server Cert Issuer #1</name>
                     <cert-data>base64encodedvalue==</cert-data>
                   </certificate>
-                </local-definition>
+                </inline-definition>
               </ca-certs>
             </server-authentication>
           </tls-client-parameters>
-          <http-client-parameters>
-            <client-identity>
-              <basic>
-                <user-id>my-name</user-id>
-                <cleartext-password>my-password</cleartext-password>
-              </basic>
-            </client-identity>
-            <path
-                xmlns="urn:ietf:params:xml:ns:yang:ietf-https-notif-transport">/some/path</path>
-          </http-client-parameters>
-        </tls>
+        </capabilities-endpoint>
+        <relay-notification-endpoint>
+          <uri>receiver.example.com:443/some-path</uri>
+          <tls-client-parameters>
+            <server-authentication>
+              <ca-certs>
+                <inline-definition>
+                  <certificate>
+                    <name>Server Cert Issuer #1</name>
+                    <cert-data>base64encodedvalue==</cert-data>
+                  </certificate>
+                </inline-definition>
+              </ca-certs>
+            </server-authentication>
+          </tls-client-parameters>
+        </relay-notification-endpoint>
         <receiver-identity>
           <cert-maps>
             <cert-to-name>

--- a/src/yang/ietf-https-notif-transport.yang
+++ b/src/yang/ietf-https-notif-transport.yang
@@ -87,7 +87,18 @@ module ietf-https-notif-transport {
     description
       "A grouping that may be used by other modules wishing to
        configure HTTPS-based notifications without using RFC 8639.";
-    uses httpc:http-client-grouping;
+    container capabilities-endpoint {
+      uses httpc:http-client-grouping;
+      description
+        "Defines 'capabilities' resource endpoint.";
+    }
+
+    container relay-notification-endpoint {
+      uses httpc:http-client-grouping;
+      description
+        "Defines 'relay-notification' resource endpoint.";
+    }
+
     container receiver-identity {
       if-feature receiver-identity;
       description

--- a/src/yang/ietf-https-notif-transport.yang
+++ b/src/yang/ietf-https-notif-transport.yang
@@ -87,27 +87,7 @@ module ietf-https-notif-transport {
     description
       "A grouping that may be used by other modules wishing to
        configure HTTPS-based notifications without using RFC 8639.";
-    uses httpc:http-client-stack-grouping {
-      refine "transport/tcp" {
-        // create the logical impossibility of enabling the
-        // "tcp" transport (i.e., "HTTP" without the 'S').
-        if-feature "not httpc:tcp-supported";
-      }
-      augment "transport/tls/tls/http-client-parameters" {
-        leaf path {
-          type string;
-          mandatory true;
-          description
-            "A path to the target resources.  Under this
-             path the receiver must support both the 'capabilities'
-             and 'relay-notification' resource targets, as described
-             in RFC XXXX.";
-        }
-        description
-          "Augmentation to add a receiver-specific path for the
-           'capabilities' and 'relay-notification' resources.";
-      }
-    }
+    uses httpc:http-client-grouping;
     container receiver-identity {
       if-feature receiver-identity;
       description


### PR DESCRIPTION
These changes are by no means complete. However, ...

The first set of changes are trying to address the use of 'http-client-grouping' directly from ietf-http-client module. But is the mapping from what used to be 'remote-address' and 'remote-port' to 'uri' correct? @kwatsen, please examine.

Also, I do not know what 'local-definition' as part of 'tls-client-parameters' in example-https-notif-7.1.xml maps to anymore. Need your help there.